### PR TITLE
Set up GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies and build
+        run: |
+          cd frontend
+          npm ci
+          npm run build
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: frontend/dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ python3 -m http.server
 ```
 
 Then navigate to `http://localhost:8000`.
+
+## Deploying to GitHub Pages
+
+This repository contains a GitHub Actions workflow that automatically builds the React app and publishes it to **GitHub Pages** whenever changes are pushed to the `main` branch. After merging your changes, enable Pages in the repository settings and select the `GitHub Actions` option to host the site.
+


### PR DESCRIPTION
## Summary
- add a workflow to deploy the Vite build to GitHub Pages
- document how to enable the GitHub Pages deployment

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684cdb6d66e8832983165bd4d513c6e6